### PR TITLE
Fix broken link to libyang and libyang3-sys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 
 Rust bindings for the [libyang] library.
 
-For raw FFI bindings for libyang, see [libyang-sys].
+For raw FFI bindings for libyang, see [libyang3-sys].
 
-[libyang]: https://github.com/CESNET/libyang/tree/libyang
-[libyang-sys]: https://github.com/holo-routing/yang-rs/tree/master/libyang-sys
+[libyang]: https://github.com/CESNET/libyang/
+[libyang3-sys]: ./libyang3-sys
 
 #### Cargo.toml
 


### PR DESCRIPTION
The first two links in the README.md are currently broken on master.

This pull request fixes the link to point to the proper destination on github.