### PR TITLE
Initial Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ bitflags = "2.5"
 num-traits = "0.2"
 num-derive = "0.4"
 
+[target.'cfg(windows)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 criterion = "0.3.3"
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,6 @@ use bitflags::bitflags;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::slice;
 use std::sync::Once;
@@ -118,7 +117,7 @@ impl Context {
         search_dir: P,
     ) -> Result<()> {
         let search_dir =
-            CString::new(search_dir.as_ref().as_os_str().as_bytes()).unwrap();
+            CString::new(search_dir.as_ref().to_str().unwrap()).unwrap();
         let ret =
             unsafe { ffi::ly_ctx_set_searchdir(self.raw, search_dir.as_ptr()) };
         if ret != ffi::LY_ERR::LY_SUCCESS {
@@ -137,7 +136,7 @@ impl Context {
         search_dir: P,
     ) -> Result<()> {
         let search_dir =
-            CString::new(search_dir.as_ref().as_os_str().as_bytes()).unwrap();
+            CString::new(search_dir.as_ref().to_str().unwrap()).unwrap();
         let ret = unsafe {
             ffi::ly_ctx_unset_searchdir(self.raw, search_dir.as_ptr())
         };


### PR DESCRIPTION
This necessitated Windows re-implementations of methods that involved file handles (like print_file) and using the ffi implementations of some types (like c_void).