### PR TITLE
data: expand the OP parsing with new API functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,10 +25,7 @@ impl Error {
         let error = unsafe { ffi::ly_err_last(ctx.raw) };
         if error.is_null() {
             return Self {
-                errcode: ffi::LY_ERR::LY_EOTHER,
-                msg: None,
-                path: None,
-                apptag: None,
+                ..Default::default()
             };
         }
 
@@ -42,6 +39,17 @@ impl Error {
             msg,
             path,
             apptag,
+        }
+    }
+}
+
+impl Default for Error {
+    fn default() -> Self {
+        Self {
+            errcode: ffi::LY_ERR::LY_EOTHER,
+            msg: None,
+            path: None,
+            apptag: None,
         }
     }
 }


### PR DESCRIPTION
The new functions handle the 3 NETCONF and 3 RESTCONF variations. It also seems like the existing `fn parse_op` is broken as it returns the envelope node which will not be the actual tree, but opaque data.