### PR TITLE
DataNodeRef with single lifetime

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -121,8 +121,8 @@ pub struct SchemaModules<'a> {
 
 /// An iterator over a list of metadata.
 #[derive(Debug)]
-pub struct MetadataList<'a, 'b> {
-    next: Option<Metadata<'a, 'b>>,
+pub struct MetadataList<'a> {
+    next: Option<Metadata<'a>>,
 }
 
 // ===== impl Siblings =====
@@ -414,16 +414,16 @@ impl<'a> Iterator for SchemaModules<'a> {
 
 // ===== impl MetadataList =====
 
-impl<'a, 'b> MetadataList<'a, 'b> {
-    pub fn new(next: Option<Metadata<'a, 'b>>) -> MetadataList<'a, 'b> {
+impl<'a> MetadataList<'a> {
+    pub fn new(next: Option<Metadata<'a>>) -> MetadataList<'a> {
         MetadataList { next }
     }
 }
 
-impl<'a, 'b> Iterator for MetadataList<'a, 'b> {
-    type Item = Metadata<'a, 'b>;
+impl<'a> Iterator for MetadataList<'a> {
+    type Item = Metadata<'a>;
 
-    fn next(&mut self) -> Option<Metadata<'a, 'b>> {
+    fn next(&mut self) -> Option<Metadata<'a>> {
         let meta = self.next.clone();
         if let Some(next) = &self.next {
             self.next = next.next();


### PR DESCRIPTION
Needed to fix way DataTree::merge worked so that the tree did not inherit the lifetime of the context reference from the source tree the changes are being merged from.

The removal of the second lifetime generic from DataNodeRef was done by Renato Westphal <renato@opensourcerouting.org>, thanks!