### PR TITLE
[yang3] `into_raw` for `Bindings`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@
 use bitflags::bitflags;
 use std::collections::HashMap;
 use std::ffi::CString;
+use std::mem::ManuallyDrop;
 use std::os::raw::{c_char, c_void};
 use std::path::Path;
 use std::slice;
@@ -124,6 +125,12 @@ impl Context {
         }
 
         Ok(Context { raw: context })
+    }
+
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the libyang context.
+    pub fn into_raw(self) -> *mut ffi::ly_ctx {
+        ManuallyDrop::new(self).raw
     }
 
     /// Add the search path into libyang context.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -179,7 +179,7 @@ pub enum DataValue {
 impl<'a> SchemaModule<'a> {
     /// Returns a mutable raw pointer to the underlying C library representation
     /// of the module.
-    pub(crate) fn raw(&self) -> *mut ffi::lys_module {
+    pub fn as_raw(&self) -> *mut ffi::lys_module {
         self.raw
     }
 
@@ -465,6 +465,12 @@ unsafe impl Sync for SchemaModule<'_> {}
 // ===== impl SchemaSubmodule =====
 
 impl SchemaSubmodule<'_> {
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the sub-module.
+    pub fn as_raw(&self) -> *mut ffi::lysp_submodule {
+        self.raw
+    }
+
     /// Print schema tree in the specified format into a string.
     pub fn print_string(
         &self,
@@ -520,6 +526,12 @@ unsafe impl Sync for SchemaSubmodule<'_> {}
 // ===== impl SchemaNode =====
 
 impl<'a> SchemaNode<'a> {
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the node.
+    pub fn as_raw(&self) -> *mut ffi::lysc_node {
+        self.raw
+    }
+
     #[doc(hidden)]
     fn check_flag(&self, flag: u32) -> bool {
         let flags = unsafe { (*self.raw).flags } as u32;
@@ -1131,6 +1143,12 @@ unsafe impl Sync for SchemaNode<'_> {}
 impl SchemaStmtMust<'_> {
     // TODO: XPath condition
 
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the must statement.
+    pub fn as_raw(&self) -> *mut ffi::lysc_must {
+        self.raw
+    }
+
     /// description substatement.
     pub fn description(&self) -> Option<&str> {
         char_ptr_to_opt_str(unsafe { (*self.raw).dsc })
@@ -1175,6 +1193,12 @@ unsafe impl Sync for SchemaStmtMust<'_> {}
 impl SchemaStmtWhen<'_> {
     // TODO: XPath condition
 
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the when statement.
+    pub fn as_raw(&self) -> *mut ffi::lysc_when {
+        self.raw
+    }
+
     /// description substatement.
     pub fn description(&self) -> Option<&str> {
         char_ptr_to_opt_str(unsafe { (*self.raw).dsc })
@@ -1208,6 +1232,12 @@ unsafe impl Sync for SchemaStmtWhen<'_> {}
 // ===== impl SchemaLeafType =====
 
 impl SchemaLeafType<'_> {
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the leaf type.
+    pub fn as_raw(&self) -> *mut ffi::lysc_type {
+        self.raw
+    }
+
     /// Returns the resolved base type.
     pub fn base_type(&self) -> DataValueType {
         let base_type = unsafe { (*self.raw).basetype };
@@ -1253,6 +1283,12 @@ unsafe impl Sync for SchemaLeafType<'_> {}
 // ===== impl SchemaExtInstance =====
 
 impl<'a> SchemaExtInstance<'a> {
+    /// Returns a mutable raw pointer to the underlying C library representation
+    /// of the extension instance.
+    pub fn as_raw(&self) -> *mut ffi::lysc_ext_instance {
+        self.raw
+    }
+
     /// Returns the optional extension's argument.
     pub fn argument(&self) -> Option<String> {
         let argument = unsafe { (*self.raw).argument };


### PR DESCRIPTION
This adds an `Bindings::into_raw` to allow turning any `Binding` into its raw pointer.

I need this as I am modifying [`sysrepo-rs`](https://github.com/sjtakada/sysrepo-rs) to remove all `libyang` bindings, replacing them with the ones from this crate.