### PR TITLE
Add the parameter output to find_path

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -269,18 +269,34 @@ pub trait Data<'a> {
     /// The expected format of the expression is JSON, meaning the first node in
     /// every path must have its module name as prefix or be the special `*`
     /// value for all the nodes.
-    fn find_path(
-        &'a self,
-        path: &str,
-        output: bool,
-    ) -> Result<DataNodeRef<'a>> {
+    fn find_path(&'a self, path: &str) -> Result<DataNodeRef<'a>> {
         let path = CString::new(path).unwrap();
         let mut rnode = std::ptr::null_mut();
         let rnode_ptr = &mut rnode;
-        let output = if output { 1u8 } else { 0u8 };
 
         let ret = unsafe {
-            ffi::lyd_find_path(self.raw(), path.as_ptr(), output, rnode_ptr)
+            ffi::lyd_find_path(self.raw(), path.as_ptr(), 0, rnode_ptr)
+        };
+        if ret != ffi::LY_ERR::LY_SUCCESS {
+            return Err(Error::new(self.context()));
+        }
+
+        Ok(unsafe { DataNodeRef::from_raw(self.tree(), rnode as *mut _) })
+    }
+
+    /// Search in the given data for a single node matching the provided XPath and
+    /// is an RPC/ output nodes or in input nodes.
+    ///
+    /// The expected format of the expression is JSON, meaning the first node in
+    /// every path must have its module name as prefix or be the special `*`
+    /// value for all the nodes.
+    fn find_output_path(&'a self, path: &str) -> Result<DataNodeRef<'a>> {
+        let path = CString::new(path).unwrap();
+        let mut rnode = std::ptr::null_mut();
+        let rnode_ptr = &mut rnode;
+
+        let ret = unsafe {
+            ffi::lyd_find_path(self.raw(), path.as_ptr(), 1, rnode_ptr)
         };
         if ret != ffi::LY_ERR::LY_SUCCESS {
             return Err(Error::new(self.context()));
@@ -758,7 +774,7 @@ impl<'a> DataTree<'a> {
 
     /// Remove a data node.
     pub fn remove(&mut self, path: &str) -> Result<()> {
-        let dnode = self.find_path(path, false)?;
+        let dnode = self.find_path(path)?;
         unsafe { ffi::lyd_free_tree(dnode.raw) };
         Ok(())
     }
@@ -994,7 +1010,7 @@ impl<'a> DataTreeOwningRef<'a> {
         let raw = {
             match tree.new_path(path, value, output)? {
                 Some(node) => node.raw,
-                None => tree.find_path(path, output)?.raw,
+                None => tree.find_path(path)?.raw,
             }
         };
         Ok(unsafe { DataTreeOwningRef::from_raw(tree, raw) })

--- a/src/data.rs
+++ b/src/data.rs
@@ -269,7 +269,11 @@ pub trait Data<'a> {
     /// The expected format of the expression is JSON, meaning the first node in
     /// every path must have its module name as prefix or be the special `*`
     /// value for all the nodes.
-    fn find_path(&'a self, path: &str, output: bool) -> Result<DataNodeRef<'a>> {
+    fn find_path(
+        &'a self,
+        path: &str,
+        output: bool,
+    ) -> Result<DataNodeRef<'a>> {
         let path = CString::new(path).unwrap();
         let mut rnode = std::ptr::null_mut();
         let rnode_ptr = &mut rnode;

--- a/src/data.rs
+++ b/src/data.rs
@@ -275,7 +275,7 @@ pub trait Data<'a> {
         let rnode_ptr = &mut rnode;
 
         let ret = unsafe {
-            ffi::lyd_find_path(self.raw(), path.as_ptr(), 0, rnode_ptr)
+            ffi::lyd_find_path(self.raw(), path.as_ptr(), 0u8, rnode_ptr)
         };
         if ret != ffi::LY_ERR::LY_SUCCESS {
             return Err(Error::new(self.context()));
@@ -296,7 +296,7 @@ pub trait Data<'a> {
         let rnode_ptr = &mut rnode;
 
         let ret = unsafe {
-            ffi::lyd_find_path(self.raw(), path.as_ptr(), 1, rnode_ptr)
+            ffi::lyd_find_path(self.raw(), path.as_ptr(), 1u8, rnode_ptr)
         };
         if ret != ffi::LY_ERR::LY_SUCCESS {
             return Err(Error::new(self.context()));

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -207,7 +207,7 @@ fn create_context() -> Context {
         "ietf-ip",
         "ietf-routing",
         "ietf-isis",
-        "ietf-mpls-ldp"
+        "ietf-mpls-ldp",
     ] {
         ctx.load_module(module_name, None, &[])
             .expect("Failed to load module");
@@ -311,7 +311,10 @@ fn data_find_path() {
         .find_path("/ietf-interfaces:interfaces/interface", false)
         .is_err());
     assert!(dtree1
-        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
+        .find_path(
+            "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
+            false
+        )
         .is_ok());
 }
 
@@ -388,7 +391,10 @@ fn data_duplicate_subtree() {
     let dtree1 = parse_json_data(&ctx, JSON_TREE1);
 
     let dnode = dtree1
-        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
+        .find_path(
+            "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
+            false,
+        )
         .expect("Failed to lookup data");
 
     // Duplicate without parents.
@@ -672,7 +678,9 @@ fn data_iterator_ancestors() {
     assert_eq!(
         dtree1
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type", false)
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type",
+                false
+            )
             .expect("Failed to lookup data")
             .ancestors()
             .map(|dnode| dnode.path())
@@ -685,7 +693,9 @@ fn data_iterator_ancestors() {
     assert_eq!(
         dtree1
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type", false)
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type",
+                false
+            )
             .expect("Failed to lookup data")
             .inclusive_ancestors()
             .map(|dnode| dnode.path())
@@ -705,7 +715,10 @@ fn data_iterator_siblings() {
 
     assert_eq!(
         dtree1
-            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
+            .find_path(
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
+                false
+            )
             .expect("Failed to lookup data")
             .siblings()
             .map(|dnode| dnode.path())
@@ -714,7 +727,10 @@ fn data_iterator_siblings() {
     );
     assert_eq!(
         dtree1
-            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
+            .find_path(
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
+                false
+            )
             .expect("Failed to lookup data")
             .inclusive_siblings()
             .map(|dnode| dnode.path())
@@ -753,7 +769,8 @@ fn data_is_default() {
     assert_eq!(
         dtree2
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/enabled", false
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/enabled",
+                false
             )
             .expect("Failed to lookup data")
             .is_default(),
@@ -762,7 +779,8 @@ fn data_is_default() {
     assert_eq!(
         dtree2
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/2']/enabled", false
+                "/ietf-interfaces:interfaces/interface[name='eth/0/2']/enabled",
+                false
             )
             .expect("Failed to lookup data")
             .is_default(),

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -207,6 +207,7 @@ fn create_context() -> Context {
         "ietf-ip",
         "ietf-routing",
         "ietf-isis",
+        "ietf-mpls-ldp"
     ] {
         ctx.load_module(module_name, None, &[])
             .expect("Failed to load module");
@@ -307,10 +308,10 @@ fn data_find_path() {
     let dtree1 = parse_json_data(&ctx, JSON_TREE1);
 
     assert!(dtree1
-        .find_path("/ietf-interfaces:interfaces/interface")
+        .find_path("/ietf-interfaces:interfaces/interface", false)
         .is_err());
     assert!(dtree1
-        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
+        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
         .is_ok());
 }
 
@@ -387,7 +388,7 @@ fn data_duplicate_subtree() {
     let dtree1 = parse_json_data(&ctx, JSON_TREE1);
 
     let dnode = dtree1
-        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
+        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
         .expect("Failed to lookup data");
 
     // Duplicate without parents.
@@ -671,8 +672,7 @@ fn data_iterator_ancestors() {
     assert_eq!(
         dtree1
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type",
-            )
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type", false)
             .expect("Failed to lookup data")
             .ancestors()
             .map(|dnode| dnode.path())
@@ -685,8 +685,7 @@ fn data_iterator_ancestors() {
     assert_eq!(
         dtree1
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type",
-            )
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type", false)
             .expect("Failed to lookup data")
             .inclusive_ancestors()
             .map(|dnode| dnode.path())
@@ -706,7 +705,7 @@ fn data_iterator_siblings() {
 
     assert_eq!(
         dtree1
-            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
+            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
             .expect("Failed to lookup data")
             .siblings()
             .map(|dnode| dnode.path())
@@ -715,7 +714,7 @@ fn data_iterator_siblings() {
     );
     assert_eq!(
         dtree1
-            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
+            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']", false)
             .expect("Failed to lookup data")
             .inclusive_siblings()
             .map(|dnode| dnode.path())
@@ -734,7 +733,7 @@ fn data_iterator_children() {
 
     assert_eq!(
         dtree1
-            .find_path("/ietf-interfaces:interfaces")
+            .find_path("/ietf-interfaces:interfaces", false)
             .expect("Failed to lookup data")
             .children()
             .map(|dnode| dnode.path())
@@ -754,7 +753,7 @@ fn data_is_default() {
     assert_eq!(
         dtree2
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/enabled"
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/enabled", false
             )
             .expect("Failed to lookup data")
             .is_default(),
@@ -763,7 +762,7 @@ fn data_is_default() {
     assert_eq!(
         dtree2
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/2']/enabled"
+                "/ietf-interfaces:interfaces/interface[name='eth/0/2']/enabled", false
             )
             .expect("Failed to lookup data")
             .is_default(),

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -162,6 +162,14 @@ static JSON_RPC1: &str = r###"
           "routing-protocol-instance-name":"main"
         }
     }"###;
+
+static JSON_RPC2_OUTPUT: &str = r###"
+    {
+        "ietf-mpls-ldp:mpls-ldp-clear-peer":{
+          "protocol-name":"test"
+        }
+    }"###;
+
 static JSON_ACTION1: &str = r###"
     {
         "ietf-routing:routing": {
@@ -308,13 +316,26 @@ fn data_find_path() {
     let dtree1 = parse_json_data(&ctx, JSON_TREE1);
 
     assert!(dtree1
-        .find_path("/ietf-interfaces:interfaces/interface", false)
+        .find_path("/ietf-interfaces:interfaces/interface")
         .is_err());
     assert!(dtree1
-        .find_path(
-            "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
-            false
+        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
+        .is_ok());
+}
+
+#[test]
+fn data_find_action_output_path() {
+    let ctx = create_context();
+    let dtree1 = parse_json_rpc_reply(&ctx, JSON_ACTION1);
+    let dtree2 = parse_json_rpc_reply(&ctx, JSON_RPC2_OUTPUT);
+
+    assert!(dtree1
+        .find_output_path(
+            "/ietf-routing:routing/ribs/rib[name='default']/active-route"
         )
+        .is_ok());
+    assert!(dtree2
+        .find_output_path("/ietf-mpls-ldp:mpls-ldp-clear-peer/protocol-name")
         .is_ok());
 }
 
@@ -391,10 +412,7 @@ fn data_duplicate_subtree() {
     let dtree1 = parse_json_data(&ctx, JSON_TREE1);
 
     let dnode = dtree1
-        .find_path(
-            "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
-            false,
-        )
+        .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
         .expect("Failed to lookup data");
 
     // Duplicate without parents.
@@ -678,8 +696,7 @@ fn data_iterator_ancestors() {
     assert_eq!(
         dtree1
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type",
-                false
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type"
             )
             .expect("Failed to lookup data")
             .ancestors()
@@ -693,8 +710,7 @@ fn data_iterator_ancestors() {
     assert_eq!(
         dtree1
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type",
-                false
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/type"
             )
             .expect("Failed to lookup data")
             .inclusive_ancestors()
@@ -715,10 +731,7 @@ fn data_iterator_siblings() {
 
     assert_eq!(
         dtree1
-            .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
-                false
-            )
+            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
             .expect("Failed to lookup data")
             .siblings()
             .map(|dnode| dnode.path())
@@ -727,10 +740,7 @@ fn data_iterator_siblings() {
     );
     assert_eq!(
         dtree1
-            .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']",
-                false
-            )
+            .find_path("/ietf-interfaces:interfaces/interface[name='eth/0/0']")
             .expect("Failed to lookup data")
             .inclusive_siblings()
             .map(|dnode| dnode.path())
@@ -749,7 +759,7 @@ fn data_iterator_children() {
 
     assert_eq!(
         dtree1
-            .find_path("/ietf-interfaces:interfaces", false)
+            .find_path("/ietf-interfaces:interfaces")
             .expect("Failed to lookup data")
             .children()
             .map(|dnode| dnode.path())
@@ -769,8 +779,7 @@ fn data_is_default() {
     assert_eq!(
         dtree2
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/enabled",
-                false
+                "/ietf-interfaces:interfaces/interface[name='eth/0/0']/enabled"
             )
             .expect("Failed to lookup data")
             .is_default(),
@@ -779,8 +788,7 @@ fn data_is_default() {
     assert_eq!(
         dtree2
             .find_path(
-                "/ietf-interfaces:interfaces/interface[name='eth/0/2']/enabled",
-                false
+                "/ietf-interfaces:interfaces/interface[name='eth/0/2']/enabled"
             )
             .expect("Failed to lookup data")
             .is_default(),


### PR DESCRIPTION
If we want to find a node in an output node, we must set the output parameter to true.
For example, when we use sysrepo to find specific values from the output. 