### PR TITLE
Rework the bundled feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,8 +76,6 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -309,15 +307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,7 +349,6 @@ name = "libyang3-sys"
 version = "0.6.0"
 dependencies = [
  "bindgen",
- "cc",
  "cmake",
  "pkg-config",
 ]

--- a/libyang3-sys/Cargo.toml
+++ b/libyang3-sys/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["external-ffi-bindings"]
 
 [build-dependencies]
 bindgen = { version = "0.68.0", optional = true }
-cc = { version = "1.0", features = ["parallel"], optional = true }
 cmake = { version = "0.1", optional = true }
 pkg-config = "0.3.27"
 
@@ -25,4 +24,4 @@ default = []
 bindgen = ["dep:bindgen"]
 # Bundle libyang3 C files into a static archive linked to this crate.
 # This removes the libyang3 dynamic link dependency.
-bundled = ["dep:cc", "dep:cmake"]
+bundled = ["dep:bindgen", "dep:cmake"]

--- a/libyang3-sys/Cargo.toml
+++ b/libyang3-sys/Cargo.toml
@@ -24,4 +24,4 @@ default = []
 bindgen = ["dep:bindgen"]
 # Bundle libyang3 C files into a static archive linked to this crate.
 # This removes the libyang3 dynamic link dependency.
-bundled = ["dep:bindgen", "dep:cmake"]
+bundled = ["dep:cmake"]

--- a/libyang3-sys/build.rs
+++ b/libyang3-sys/build.rs
@@ -6,6 +6,7 @@ fn main() {
     let out_file = dst.join("libyang3.rs");
 
     #[cfg(feature = "bindgen")]
+    #[cfg(not(feature = "bundled"))]
     {
         // Generate Rust FFI to libyang.
         println!("cargo:rerun-if-changed=wrapper.h");
@@ -35,109 +36,49 @@ fn main() {
     {
         use std::path::Path;
         use std::process::Command;
-
         // Initialize the libyang submodule if necessary.
         if !Path::new("libyang/.git").exists() {
             let _ = Command::new("git")
                 .args(&["submodule", "update", "--init"])
                 .status();
         }
-
-        // Run cmake.
-        let cmake_dst = cmake::build("libyang");
-
-        // Build libyang3.
-        let mut build = cc::Build::new();
-        build
-            .include(format!("{}/build/compat", cmake_dst.display()))
-            .include(format!("{}/build/src", cmake_dst.display()))
-            .include(format!("{}/build/libyang", cmake_dst.display()))
-            .include("libyang/src")
-            .include("libyang/src/plugins_exts")
-            .file("libyang/compat/compat.c")
-            .file("libyang/src/context.c")
-            .file("libyang/src/dict.c")
-            .file("libyang/src/diff.c")
-            .file("libyang/src/hash_table.c")
-            .file("libyang/src/in.c")
-            .file("libyang/src/json.c")
-            .file("libyang/src/log.c")
-            .file("libyang/src/lyb.c")
-            .file("libyang/src/ly_common.c")
-            .file("libyang/src/out.c")
-            .file("libyang/src/parser_common.c")
-            .file("libyang/src/parser_json.c")
-            .file("libyang/src/parser_lyb.c")
-            .file("libyang/src/parser_xml.c")
-            .file("libyang/src/parser_yang.c")
-            .file("libyang/src/parser_yin.c")
-            .file("libyang/src/path.c")
-            .file("libyang/src/plugins.c")
-            .file("libyang/src/plugins_exts.c")
-            .file("libyang/src/plugins_exts/metadata.c")
-            .file("libyang/src/plugins_exts/nacm.c")
-            .file("libyang/src/plugins_exts/schema_mount.c")
-            .file("libyang/src/plugins_exts/structure.c")
-            .file("libyang/src/plugins_exts/yangdata.c")
-            .file("libyang/src/plugins_types.c")
-            .file("libyang/src/plugins_types/binary.c")
-            .file("libyang/src/plugins_types/bits.c")
-            .file("libyang/src/plugins_types/boolean.c")
-            .file("libyang/src/plugins_types/date_and_time.c")
-            .file("libyang/src/plugins_types/decimal64.c")
-            .file("libyang/src/plugins_types/empty.c")
-            .file("libyang/src/plugins_types/enumeration.c")
-            .file("libyang/src/plugins_types/hex_string.c")
-            .file("libyang/src/plugins_types/identityref.c")
-            .file("libyang/src/plugins_types/instanceid.c")
-            .file("libyang/src/plugins_types/instanceid_keys.c")
-            .file("libyang/src/plugins_types/integer.c")
-            .file("libyang/src/plugins_types/ipv4_address.c")
-            .file("libyang/src/plugins_types/ipv4_address_no_zone.c")
-            .file("libyang/src/plugins_types/ipv4_prefix.c")
-            .file("libyang/src/plugins_types/ipv6_address.c")
-            .file("libyang/src/plugins_types/ipv6_address_no_zone.c")
-            .file("libyang/src/plugins_types/ipv6_prefix.c")
-            .file("libyang/src/plugins_types/leafref.c")
-            .file("libyang/src/plugins_types/lyds_tree.c")
-            .file("libyang/src/plugins_types/node_instanceid.c")
-            .file("libyang/src/plugins_types/time_period.c")
-            .file("libyang/src/plugins_types/string.c")
-            .file("libyang/src/plugins_types/union.c")
-            .file("libyang/src/plugins_types/xpath1.0.c")
-            .file("libyang/src/printer_data.c")
-            .file("libyang/src/printer_json.c")
-            .file("libyang/src/printer_lyb.c")
-            .file("libyang/src/printer_schema.c")
-            .file("libyang/src/printer_tree.c")
-            .file("libyang/src/printer_xml.c")
-            .file("libyang/src/printer_yang.c")
-            .file("libyang/src/printer_yin.c")
-            .file("libyang/src/schema_compile_amend.c")
-            .file("libyang/src/schema_compile.c")
-            .file("libyang/src/schema_compile_node.c")
-            .file("libyang/src/schema_features.c")
-            .file("libyang/src/set.c")
-            .file("libyang/src/tree_data.c")
-            .file("libyang/src/tree_data_common.c")
-            .file("libyang/src/tree_data_free.c")
-            .file("libyang/src/tree_data_hash.c")
-            .file("libyang/src/tree_data_new.c")
-            .file("libyang/src/tree_data_sorted.c")
-            .file("libyang/src/tree_schema.c")
-            .file("libyang/src/tree_schema_common.c")
-            .file("libyang/src/tree_schema_free.c")
-            .file("libyang/src/validation.c")
-            .file("libyang/src/xml.c")
-            .file("libyang/src/xpath.c")
-            .warnings(false);
-
-        build.compile("yang3");
+        // Run cmake configure and build libyang
+        let mut cmake_config = cmake::Config::new("libyang");
+        cmake_config.define("BUILD_SHARED_LIBS", "OFF"); // Force static linking
+        cmake_config.define("ENABLE_TESTS", "OFF");
+        cmake_config.define("ENABLE_VALGRIND_TESTS", "OFF");
+        cmake_config.define("ENABLE_BUILD_TESTS", "OFF");
+        cmake_config.define("CMAKE_BUILD_TYPE", "Release");
+        cmake_config.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
+        let cmake_dst = cmake_config.build();
         println!("cargo:root={}", env::var("OUT_DIR").unwrap());
+        println!("cargo:rustc-link-search=native={}/lib", cmake_dst.display());
+        println!(
+            "cargo:rustc-link-search=native={}/lib64",
+            cmake_dst.display()
+        );
         if let Err(e) = pkg_config::Config::new().probe("libpcre2-8") {
             println!("cargo:warning=failed to find pcre2 library with pkg-config: {}", e);
             println!("cargo:warning=attempting to link without pkg-config");
             println!("cargo:rustc-link-lib=pcre2-8");
+        }
+        println!("cargo:rustc-link-lib=static=yang");
+        println!("cargo:rerun-if-changed=libyang");
+
+        #[cfg(feature = "bindgen")]
+        {
+            // Use the newly compiled libyang code to generate Rust FFI to libyang
+            println!("cargo:rerun-if-changed=wrapper.h");
+            let bindings = bindgen::Builder::default()
+                .header("wrapper.h")
+                .clang_arg(format!("-I{}/include", cmake_dst.display()))
+                .derive_default(true)
+                .default_enum_style(bindgen::EnumVariation::ModuleConsts)
+                .generate()
+                .expect("Unable to generate libyang3 bindings");
+            bindings
+                .write_to_file(out_file)
+                .expect("Couldn't write libyang3 bindings!");
         }
     }
     #[cfg(not(feature = "bundled"))]


### PR DESCRIPTION
yang-rs with bundled feature is building a shared libyang object, not a static one as expected by this feature. This PR reworks the implementation of bundled flag to use only `cmake` for the build with the correct flags to generate a static object `.a`. Also, remove the manual build steps using `cc`. See https://github.com/CESNET/libyang/blob/master/doc/build.dox#L61.

The bindgen feature now regenerates bindings based on the newly compiled code if the bundled feature is enabled.


This old implementation if verified to be buggy when yang-rs is compiled on a system without libyang installed:

- Using bundled only, generated a shared object '.so` not a staticaly linked object `.a`
```
$ cargo build --examples --features=bundled
   Compiling proc-macro2 v1.0.94
   Compiling unicode-ident v1.0.18
   Compiling libc v0.2.171
   Compiling crossbeam-utils v0.8.21
   Compiling shlex v1.3.0
   Compiling serde v1.0.219
   Compiling autocfg v1.4.0
   Compiling either v1.15.0
   Compiling serde_json v1.0.140
   Compiling rayon-core v1.12.1
   Compiling pkg-config v0.3.32
   Compiling cfg-if v1.0.0
   Compiling half v2.5.0
   Compiling ciborium-io v0.2.2
   Compiling memchr v2.7.4
   Compiling clap_lex v0.7.4
   Compiling num-traits v0.2.19
   Compiling ryu v1.0.20
   Compiling itoa v1.0.15
   Compiling crossbeam-epoch v0.9.18
   Compiling regex-syntax v0.8.5
   Compiling plotters-backend v0.3.7
   Compiling quote v1.0.40
   Compiling crossbeam-deque v0.8.6
   Compiling syn v2.0.100
   Compiling anstyle v1.0.10
   Compiling plotters-svg v0.3.7
   Compiling jobserver v0.1.32
   Compiling ciborium-ll v0.2.2
   Compiling clap_builder v4.5.32
   Compiling itertools v0.10.5
   Compiling cc v1.2.16
   Compiling same-file v1.0.6
   Compiling cast v0.3.0
   Compiling rayon v1.10.0
   Compiling walkdir v2.5.0
   Compiling regex-automata v0.4.9
   Compiling plotters v0.3.7
   Compiling cmake v0.1.54
   Compiling criterion-plot v0.5.0
   Compiling libyang3-sys v0.6.0 (/home/taaahel1/repos/yang-rs/libyang3-sys)
   Compiling clap v4.5.32
   Compiling is-terminal v0.4.16
   Compiling anes v0.1.6
   Compiling oorandom v11.1.5
   Compiling once_cell v1.21.1
   Compiling bitflags v2.9.0
   Compiling regex v1.11.1
   Compiling serde_derive v1.0.219
   Compiling num-derive v0.4.2
   Compiling ciborium v0.2.2
   Compiling tinytemplate v1.2.1
   Compiling criterion v0.5.1
   Compiling yang3 v0.16.0 (/home/taaahel1/repos/yang-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.99s


$ ls target/debug/build/libyang3-sys-27658a0a9ae91b08/out/lib64/
 libyang.so  libyang.so.3  libyang.so.3.9.5  pkgconfig
```

- Using bindgen + bundled will not work:
```
[taaahel1@daisy-playground-rh8 yang-rs]$ cargo build --examples --features=bindgen,bundled
   Compiling libc v0.2.171
   Compiling either v1.15.0
   Compiling glob v0.3.2
   Compiling regex-syntax v0.8.5
   Compiling rustix v0.38.44
   Compiling prettyplease v0.2.31
   Compiling bitflags v2.9.0
   Compiling syn v2.0.100
   Compiling linux-raw-sys v0.4.15
   Compiling minimal-lexical v0.2.1
   Compiling libloading v0.8.6
   Compiling clang-sys v1.8.1
   Compiling home v0.5.11
   Compiling bindgen v0.68.1
   Compiling nom v7.1.3
   Compiling peeking_take_while v0.1.2
   Compiling log v0.4.26
   Compiling lazy_static v1.5.0
   Compiling lazycell v1.3.0
   Compiling rustc-hash v1.1.0
   Compiling itertools v0.10.5
   Compiling rayon v1.10.0
   Compiling regex-automata v0.4.9
   Compiling jobserver v0.1.32
   Compiling cexpr v0.6.0
   Compiling which v4.4.2
   Compiling cc v1.2.16
   Compiling is-terminal v0.4.16
   Compiling criterion-plot v0.5.0
   Compiling regex v1.11.1
   Compiling cmake v0.1.54
   Compiling serde_derive v1.0.219
   Compiling num-derive v0.4.2
   Compiling serde v1.0.219
   Compiling libyang3-sys v0.6.0 (/home/taaahel1/repos/yang-rs/libyang3-sys)
   Compiling serde_json v1.0.140
   Compiling ciborium v0.2.2
   Compiling tinytemplate v1.2.1
   Compiling criterion v0.5.1
error: failed to run custom build command for `libyang3-sys v0.6.0 (/home/taaahel1/repos/yang-rs/libyang3-sys)`

Caused by:
  process didn't exit successfully: `/home/taaahel1/repos/yang-rs/target/debug/build/libyang3-sys-2910d1ccc2bd45d4/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=wrapper.h

  --- stderr
  wrapper.h:1:10: fatal error: 'libyang/libyang.h' file not found

  thread 'main' panicked at libyang3-sys/build.rs:17:14:
  Unable to generate libyang3 bindings: ClangDiagnostic("wrapper.h:1:10: fatal error: 'libyang/libyang.h' file not found\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```