### PR TITLE
Fix null pointer exception in extensions method

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -414,6 +414,9 @@ impl<'a> SchemaModule<'a> {
     /// Returns an iterator over the list of extension instances.
     pub fn extensions(&self) -> impl Iterator<Item = SchemaExtInstance<'a>> {
         let compiled = unsafe { (*self.raw).compiled };
+        if compiled.is_null() {
+            return Array::new(self.context, std::ptr::null_mut(), 0);
+        }
         let array = unsafe { (*compiled).exts };
         let ptr_size = mem::size_of::<ffi::lysc_ext_instance>();
         Array::new(self.context, array as *mut _, ptr_size)

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -625,3 +625,12 @@ fn test_create_context_from_yang_library_str() {
 
     assert_eq!(module_names, expected);
 }
+
+#[test]
+fn test_extensions_uncompiled_modules() {
+    let ctx = create_context();
+    // ietf-yang-metadata is an internal module and it's not compiled
+    let module = ctx.get_module_latest("ietf-yang-metadata").unwrap();
+    let extensions = module.extensions().collect::<Vec<_>>();
+    assert_eq!(extensions.len(), 0);
+}


### PR DESCRIPTION
Extensions method should only check for extensions if the yang module is compiled otherwise a null pointer causes a segfault.